### PR TITLE
quick fix for credentials not found error

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,12 @@ const { selectDialog, getDialogName } = require("./modules/dialoges");
 const { getMessages } = require("./modules/messages");
 const { logMessage } = require("./utils/helper");
 const { updateCredentials, getLastSelection, getCredentials } = require("./utils/file_helper");
-let { apiHash, apiId, sessionId } = getCredentials()
+// let { apiHash, apiId, sessionId } = getCredentials()
+let { apiHash, apiId, sessionId } = {
+                                    "apiId": xxx,
+                                    "apiHash": "xxx",
+                                    "sessionId": ""
+                                    }
 
 
 const stringSession = new StringSession(sessionId || "");


### PR DESCRIPTION
the parsing function might be the error. Works with this quick fix. Replace xxx with your own deets.